### PR TITLE
Prevent build_and_run script from exiting silently with an error if n…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# TBD
+* Small bugfix in `build_and_run.sh`, so it won't silently error on missing an argument
+
 # 0.10.0
 * Upgraded to Kurtosis 1.0
 * Centralized run scripts into `build_and_run.sh`

--- a/scripts/build_and_run.sh
+++ b/scripts/build_and_run.sh
@@ -32,6 +32,11 @@ show_help() {
     echo ""
 }
 
+if [ "${#}" -eq 0 ]; then
+    show_help
+    exit 0
+fi
+
 action="${1:-}"
 shift 1
 


### PR DESCRIPTION
…o action is specified